### PR TITLE
Make it work for async functions

### DIFF
--- a/PyBugReporter/src/BugReporter.py
+++ b/PyBugReporter/src/BugReporter.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import sys
 import traceback
 from functools import wraps
@@ -93,20 +94,38 @@ class BugReporter:
         Args:
             func (callable): the function to be decorated
         """
-        @wraps(func)
-        def wrapper(*args, **kwargs) -> None:
-            """Wrapper function that catches exceptions and sends a bug report to the github repository.
-
-            Args:
-                *args: the arguments for the function
-                **kwargs: the keyword arguments for the function
-            """
-            repoName = self.repoName
-            try:
-                return func(*args, **kwargs)
-            except Exception as e:
-                self._handleError(e, repoName, *args, **kwargs)
-        return wrapper
+        if inspect.iscoroutinefunction(func):
+            @wraps(func)
+            async def async_wrapper(*args, **kwargs) -> None:
+                """Wrapper function that catches exceptions and sends a bug report to the github repository.
+                Works for async functions.
+                
+                Args:
+                    *args: the arguments for the function
+                    **kwargs: the keyword arguments for the function
+                """
+                repoName = self.repoName
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    self._handleError(e, repoName, *args, **kwargs)
+            return async_wrapper
+        else:
+            @wraps(func)
+            def sync_wrapper(*args, **kwargs) -> None:
+                """Wrapper function that catches exceptions and sends a bug report to the github repository.
+                Works for synchronous functions.
+                
+                Args:
+                    *args: the arguments for the function
+                    **kwargs: the keyword arguments for the function
+                """
+                repoName = self.repoName
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    self._handleError(e, repoName, *args, **kwargs)
+            return sync_wrapper
 
     def _handleError(self, e: Exception, repoName: str, *args, **kwargs) -> None:
         """Handles error by creating a bug report.

--- a/PyBugReporter/src/BugReporter.py
+++ b/PyBugReporter/src/BugReporter.py
@@ -108,7 +108,7 @@ class BugReporter:
                 try:
                     return func(*args, **kwargs)
                 except Exception as e:
-                    self._handleError(e, repoName, *args, **kwargs)
+                    await self._handleError_async(e, repoName, *args, **kwargs)
             return async_wrapper
         else:
             @wraps(func)
@@ -136,6 +136,37 @@ class BugReporter:
         Raises:
             e: the exception that was raised
         """
+        title, description, shortDescription = self._prepare_bug_report(e, repoName, args, kwargs)
+
+        # Check if we need to send a bug report
+        if not self.handlers[repoName].test:
+            self._sendBugReport(repoName, title, description, shortDescription)
+
+        print(title)
+        print(description)
+        raise e
+    
+    async def _handleError_async(self, e: Exception, repoName: str, *args, **kwargs) -> None:
+        """Handles error by creating a bug report.
+
+        Args:
+            e (Exception): the exception that was raised
+
+        Raises:
+            e: the exception that was raised
+        """
+        title, description, shortDescription = self._prepare_bug_report(e, repoName, args, kwargs)
+
+        # Check if we need to send a bug report
+        if not self.handlers[repoName].test:
+            await self._sendBugReport_async(repoName, title, description, shortDescription)
+
+        print(title)
+        print(description)
+        raise e
+
+
+    def _prepare_bug_report(self, e, repoName, args, kwargs):
         excType = type(e).__name__
         tb = traceback.extract_tb(sys.exc_info()[2])
         functionName = tb[-1][2]
@@ -163,15 +194,7 @@ class BugReporter:
             shortDescription = f"{start}{compress[:2000 - staticLength]}{end}"
 
         print(f"SHORT DESCRIPTION with length {len(shortDescription)}:\n{shortDescription}")
-        
-
-        # Check if we need to send a bug report
-        if not self.handlers[repoName].test:
-            self._sendBugReport(repoName, title, description, shortDescription)
-
-        print(title)
-        print(description)
-        raise e
+        return title,description,shortDescription
 
     def _sendBugReport(self, repoName: str, errorTitle: str, errorMessage: str, shortErrorMessage: str) -> None:
         """Sends a bug report to the Github repository.

--- a/PyBugReporter/src/BugReporter.py
+++ b/PyBugReporter/src/BugReporter.py
@@ -96,7 +96,7 @@ class BugReporter:
         """
         if inspect.iscoroutinefunction(func):
             @wraps(func)
-            async def async_wrapper(*args, **kwargs) -> None:
+            async def wrapper_async(*args, **kwargs) -> None:
                 """Wrapper function that catches exceptions and sends a bug report to the github repository.
                 Works for async functions.
                 
@@ -109,10 +109,10 @@ class BugReporter:
                     return func(*args, **kwargs)
                 except Exception as e:
                     await self._handleError_async(e, repoName, *args, **kwargs)
-            return async_wrapper
+            return wrapper_async
         else:
             @wraps(func)
-            def sync_wrapper(*args, **kwargs) -> None:
+            def wrapper(*args, **kwargs) -> None:
                 """Wrapper function that catches exceptions and sends a bug report to the github repository.
                 Works for synchronous functions.
                 
@@ -125,7 +125,7 @@ class BugReporter:
                     return func(*args, **kwargs)
                 except Exception as e:
                     self._handleError(e, repoName, *args, **kwargs)
-            return sync_wrapper
+            return wrapper
 
     def _handleError(self, e: Exception, repoName: str, *args, **kwargs) -> None:
         """Handles error by creating a bug report.
@@ -147,7 +147,7 @@ class BugReporter:
         raise e
     
     async def _handleError_async(self, e: Exception, repoName: str, *args, **kwargs) -> None:
-        """Handles error by creating a bug report.
+        """Handles error by creating a bug report asynchronously.
 
         Args:
             e (Exception): the exception that was raised
@@ -166,7 +166,16 @@ class BugReporter:
         raise e
 
 
-    def _prepare_bug_report(self, e, repoName, args, kwargs):
+    def _prepare_bug_report(self, e: Exception, repoName: str, *args, **kwargs) -> tuple[str,str,str]:
+        """Prepares all information needed to send the bug report.
+
+        Args:
+            e (Exception): the exception that was raised
+
+        Returns:
+            tuple[str,str,str]: The title, description, and short description of the error for the report.
+        
+        """
         excType = type(e).__name__
         tb = traceback.extract_tb(sys.exc_info()[2])
         functionName = tb[-1][2]


### PR DESCRIPTION
I'm getting some asyncio errors from auditor in its runs. The cause seems to be bug reporter calling asyncio.run when that's how auditor is ran already. This pr should fix that by just awaiting the async function directly if it's already in an async thread.